### PR TITLE
Move the footer to the bottom of the page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,6 @@
     justify-content: space-between;
     height: 100vh;
 }
-
 .sb-tooltip
 {
     border: 0 none #ccc;

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,10 @@
+.App{
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100vh;
+}
+
 .sb-tooltip
 {
     border: 0 none #ccc;

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -72,6 +72,8 @@ const RouterComponent = () => {
                 <>
                   <Header />
                   <IncomeStatement Context={Context} />
+                  <Footer />
+                  <SupportPopUp Context={Context} />
                 </>
               </ProtectedRoutes>
             }


### PR DESCRIPTION
Move the footer to the bottom of the page.

Changes Made:
* Created a new CSS rule in App.css to position the footer at the bottom of the page.
* Tested the changes across different screen sizes and browsers to ensure responsiveness.

[Imgur](https://i.imgur.com/ZOU0hEJ.png)