### PR TITLE
build: :building_construction: babel dependencies and jwt-decode

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.1",

--- a/src/queries/auth.ts
+++ b/src/queries/auth.ts
@@ -1,4 +1,4 @@
-import jwtDecode from 'jwt-decode'
+import { jwtDecode } from 'jwt-decode'
 import { LoginSchema, SignupSchema } from '@/schema/auth'
 import { tokenClient, userClient } from '@/utils/client'
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '@/utils/constants'


### PR DESCRIPTION
Added babel dependencies for fix build warning and fixed build error for jwtDecode

- Previously we getting this warning from build
```
"@babel/plugin-proposal-private-property-in-object" package without
declaring it in its dependencies. This is currently working because
"@babel/plugin-proposal-private-property-in-object" is already in your
node_modules folder for unrelated reasons, but it may break at any time......
```
- For encounter this error i have added dev dependency like this and warning has fixed
`npm install --save-dev @babel/plugin-proposal-private-property-in-object`

- We get New error from `jwt-decode` package
`Attempted import error: 'jwt-decode' does not contain a default export (imported as 'jwtDecode')`

- So I have official package docs and i found that this package is updated 4 days ago. and one migration update that i found [here ](https://github.com/auth0/jwt-decode/blob/main/CHANGELOG.md#migration-to-v400)

- I have modify `src/queries/auth.ts` file as bellow
`import { jwtDecode } from 'jwt-decode'`

This PR fix the issue #317 