### PR TITLE
fix: current date issue in calendar

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -16,12 +16,12 @@ export type DatePickerProps = Omit<CalendarProps, 'onSelect'> & {
 
 export default function DatePicker({ className, style, onChange, placeholder, value, ...props }: DatePickerProps) {
   const [date, setDate] = React.useState<Date | undefined>(value)
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
 
   useEffect(() => {
     setDate(value)
   }, [value])
 
-  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
   return (
     <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
       <PopoverTrigger asChild>
@@ -39,7 +39,7 @@ export default function DatePicker({ className, style, onChange, placeholder, va
           mode='single'
           captionLayout='dropdown-buttons'
           selected={date}
-          onSelect={(selectedDate) => {
+          onDayClick={(selectedDate) => {
             setDate(selectedDate)
             onChange?.(selectedDate)
             setIsCalendarOpen(false)

--- a/src/pages/Lending/components/AddOrEditTransaction/AddOrEditTransaction.tsx
+++ b/src/pages/Lending/components/AddOrEditTransaction/AddOrEditTransaction.tsx
@@ -18,7 +18,7 @@ import {
   fetchLendingAccounts,
   updateLendingTransaction,
 } from '@/queries/lending'
-import { PAYMENT_METHODS, TRANNACTION_TYPES, calculateTransactionAmount } from '@/utils/lending'
+import { PAYMENT_METHODS, TRANSACTION_TYPES, calculateTransactionAmount } from '@/utils/lending'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 
 type Props = {
@@ -100,7 +100,7 @@ export default function AddOrEditTransaction({ transaction, trigger }: Props) {
         id: 'type',
         label: 'Select Type',
         type: 'select',
-        options: TRANNACTION_TYPES,
+        options: TRANSACTION_TYPES,
       },
       {
         id: 'lending_account',

--- a/src/utils/lending.ts
+++ b/src/utils/lending.ts
@@ -8,7 +8,7 @@ export function calculateTransactionAmount(type: 'lend' | 'borrow', amount: numb
   }
 }
 
-export const TRANNACTION_TYPES = [
+export const TRANSACTION_TYPES = [
   { id: 'lend', value: 'Lend', label: 'Lend' },
   { id: 'borrow', value: 'Borrow', label: 'Borrow' },
 ]


### PR DESCRIPTION
This pull request addresses problem #527. 
Users were unable to select the current date when a default date was already set. 
The issue stems from the library, so I've switched to using `onDayClick` instead of `onSelect` to resolve it.